### PR TITLE
No Go Get

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,6 @@ dist: trusty
 language: go
 go: 1.8.3
 go_import_path: github.com/codedellemc/goioc
+
+install: true
+script:  go test -v .


### PR DESCRIPTION
This patch removes the "go get" step from the Travis-CI build script.